### PR TITLE
Relax cabal constraints and hlint/style changes

### DIFF
--- a/fsutils.cabal
+++ b/fsutils.cabal
@@ -19,4 +19,5 @@ library
   hs-source-dirs:   src
   exposed-modules:  System.Path     
   -- other-modules:       
-  build-depends:    base ==4.5.*, filepath ==1.3.0.*, directory ==1.1.0.*
+  build-depends:    base >= 4.5 && < 4.7,
+                    filepath ==1.3.0.*, directory >=1.1.0 && < 1.3


### PR DESCRIPTION
Works with GHC 7.6, so relaxes cabal constraints to support that.
Also did a review and changed some stuff (e.g: sequence on a map result to mapM, eta reduce when it would be a bug to use the result anywhere in the where clause, etc).
